### PR TITLE
Update util.py

### DIFF
--- a/sample/util.py
+++ b/sample/util.py
@@ -175,7 +175,7 @@ def key_with_max_value(item):
     return max(item.items(), key=operator.itemgetter(1))[0]
 
 
-def async(func):
+async def func()::
     """Async wrapper."""
 
     def wrapper(*args, **kwargs):


### PR DESCRIPTION
With Python 3.7 running sample.py will raise this error
  File "sample\util.py", line 178
    def async(func):
            ^
SyntaxError: invalid syntax

Patch for the above
